### PR TITLE
ci: fix tagged released workflow

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -15,11 +15,13 @@ jobs:
         working-directory: .
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.23
+        uses: actions/setup-go@v5
+        with:
+          go-version: ^1.23
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
ci fails with

>   go install github.com/rakyll/statik
>   statik -f -src=./public -dest=server/ -p public
>   make: statik: No such file or directory
>   make: *** [Makefile:9: static] Error 127
>   Error: Process completed with exit code 2.